### PR TITLE
improve special case and add special criteria

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ It is based on Meeting SDK for Windows, Version 5.14.0
 
 Here are some assumptions
 
+- The user who use the bot choose the customized interface
 - The user who is accessing raw audio and raw video has host, co-host, or recording permission
 - The SDK has successfully joined the meeting, subsequently has an "in meeting" status, and "start recording status" before raw audio and raw video can be access
 - The code snipplets' starting point happens when user clicks on the "local record" button in Custom UI
@@ -33,6 +34,10 @@ Convert `360.yuv`, `720.yuv` and `1080.yuv` to a playable mp4 file by using eith
  - `ffmpeg -f rawvideo -vcodec rawvideo -s 640x360 -r 25 -pix_fmt yuv420p -i 360.yuv -c:v libx264 360.mp4`
  - `ffmpeg -f rawvideo -vcodec rawvideo -s 1280x720 -r 25 -pix_fmt yuv420p -i 720.yuv -c:v libx264 720.mp4`
  - `ffmpeg -f rawvideo -vcodec rawvideo -s 1920x1080 -r 25 -pix_fmt yuv420p -i 1080.yuv -c:v libx264 1080.mp4`
+
+> If in RawVideoDelegate.cpp, on RawDataFrameReceive the name is output.yuv name a command that can be used to convert is the same as
+
+ - `ffmpeg -s 640x480 -i .\output.yuv -ss 00:00:00 -c:v libx264 -s:v 640x480 -t 00:08:20 output.mp4`
 
 ## Troubleshooting
 


### PR DESCRIPTION
Great work on providing a demo of how to access raw audio and raw video using Custom UI on the Zoom Meeting SDK for Windows version 5.14.0. It's helpful that you have provided assumptions and clear instructions on how to add/alter the code.

One suggestion that we found. In some cases when we test the video in different users the ffmpeg command don't work correctly, there are diferrent R-G-B position color in the video, in this cases , we use 


`ffmpeg -s 640x480 -i .\output.yuv -ss 00:00:00 -c:v libx264 -s:v 640x480 -t 00:08:20 output.mp4`



